### PR TITLE
Add Save Layout setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
         },
         "mcu-debug.peripheral-viewer.saveLayout": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Save layout of peripheral view between sessions"
         }
       }

--- a/package.json
+++ b/package.json
@@ -281,6 +281,11 @@
           "maximum": 2,
           "multipleOf": 1,
           "description": "Enable debug output in the OUTPUT Tab (Peripheral Viewer section). Some debug output may also be found in the `Mcu-debug Tracker` section which is controlled separately. Changing this value requires a Reload of the window"
+        },
+        "mcu-debug.peripheral-viewer.saveLayout": {
+          "type": "boolean",
+          "default": false,
+          "description": "Save layout of peripheral view between sessions"
         }
       }
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -13,4 +13,5 @@ export const CONFIG_ADDRGAP = 'svdAddrGapThreshold';
 export const DEFAULT_ADDRGAP = 16;
 export const CONFIG_ASSET_PATH = 'packAssetUrl';
 export const DEFAULT_ASSET_PATH = 'https://pack-asset-service.keil.arm.com';
+export const CONFIG_SAVE_LAYOUT = 'saveLayout';
 export const DEBUG_LEVEL = 'debugLevel';

--- a/src/views/peripheral.ts
+++ b/src/views/peripheral.ts
@@ -68,13 +68,19 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
     }
 
     private async loadSvdState(context: vscode.ExtensionContext): Promise<NodeSetting[]> {
+        const saveLayout = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(manifest.CONFIG_SAVE_LAYOUT);
+        if (!saveLayout) {
+            return [];
+        }
+
         const propName = PeripheralTreeForSession.getStatePropName(this.session);
         const state = context.workspaceState.get(propName) as NodeSetting[] || [];
         return state;
     }
 
     private async saveSvdState(state: NodeSetting[], context: vscode.ExtensionContext): Promise<void> {
-        if (this.session) {
+        const saveLayout = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(manifest.CONFIG_SAVE_LAYOUT);
+        if (saveLayout && this.session) {
             const propName = PeripheralTreeForSession.getStatePropName(this.session);
             context.workspaceState.update(propName, state);
         }


### PR DESCRIPTION
This adds a setting to control whether the layout is saved between sessions or not.

There are situations where the saved state can interfere with usage:

- In the browser version, the user needs write access to the workspace
- If a memory area is unreachable it can bring down the debug session, but then get in a reset loop because the next session immediately tries to reload the same area due to the state opening it back up.

~~Therefore recommend the state saving is off by default.~~