### PR TITLE
Update view name to `Peripherals`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "debug": [
         {
           "id": "mcu-debug.peripheral-viewer.svd",
-          "name": "XPeripherals",
+          "name": "Peripherals",
           "when": "mcu-debug.peripheral-viewer.hadData"
         }
       ]


### PR DESCRIPTION
The view name is currently `XPeripherals` (I assume due to testing alongside `cortex-debug`).

This PR fixes the name