### PR TITLE
Guard against activation crashes

### DIFF
--- a/src/debug-tracker-wrapper.ts
+++ b/src/debug-tracker-wrapper.ts
@@ -76,12 +76,17 @@ export class DebugTrackerWrapper {
     }
 
     private async getTracker(context: vscode.ExtensionContext): Promise<IDebugTracker | undefined> {
-        // If the extension was already installed and available, get the API handle from it, or
-        // else create one locally
         let ret: IDebugTracker | undefined;
-        const trackerExtension = vscode.extensions.getExtension<IDebugTracker>(TRACKER_EXT_ID);
-        if (trackerExtension) {
-            ret = await trackerExtension.activate();
+
+        try {
+            // If the extension was already installed and available, get the API handle from it, or
+            // else create one locally
+            const trackerExtension = vscode.extensions.getExtension<IDebugTracker>(TRACKER_EXT_ID);
+            if (trackerExtension) {
+                ret = await trackerExtension.activate();
+            }
+        } catch(_e) {
+            // Ignore error
         }
 
         if (!ret) {

--- a/src/svd-registry.ts
+++ b/src/svd-registry.ts
@@ -47,13 +47,17 @@ export class SvdRegistry {
     }
 
     public async getSVDFileFromCortexDebug(device: string): Promise<string | undefined> {
-        // Try loading from device support pack registered with this extension
-        const cortexDebug = vscode.extensions.getExtension<SvdRegistry>(CORTEX_EXTENSION);
-        if (cortexDebug) {
-            const cdbg = await cortexDebug.activate();
-            if (cdbg) {
-                return cdbg.getSVDFile(device);
+        try {
+            // Try loading from device support pack registered with this extension
+            const cortexDebug = vscode.extensions.getExtension<SvdRegistry>(CORTEX_EXTENSION);
+            if (cortexDebug) {
+                const cdbg = await cortexDebug.activate();
+                if (cdbg) {
+                    return cdbg.getSVDFile(device);
+                }
             }
+        } catch(_e) {
+            // Ignore error
         }
 
         return undefined;


### PR DESCRIPTION
In Theia-based applications some extension checks and activations can throw errors which stop this extension from working.

This PR adds some try..catch guards around the extension activations to prevent errors from interfering with the operation.