### PR TITLE
Fix for no processors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,9 @@
             "name": "Desktop Extension",
             "type": "extensionHost",
             "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"
             ]

--- a/src/svd-resolver.ts
+++ b/src/svd-resolver.ts
@@ -10,7 +10,6 @@ import { SvdRegistry } from './svd-registry';
 import { parsePackString, pdscFromPack, fileFromPack, Pack } from './cmsis-pack/pack-utils';
 import { PDSC, Device, DeviceVariant, getDevices, getSvdPath, getProcessors } from './cmsis-pack/pdsc';
 import { readFromUrl } from './utils';
-import { getSelection } from './vscode-utils';
 
 export class SvdResolver {
     public constructor(protected registry: SvdRegistry) {
@@ -99,8 +98,7 @@ export class SvdResolver {
             packDevice = devices[0];
         } else {
             // Ask user which device to use
-            const items = [...deviceMap.keys()].map(label => ({ label }));
-            const selected = await getSelection('Select a device', items, deviceName);
+            const selected = await vscode.window.showQuickPick([...deviceMap.keys()], { title: 'Select a device', placeHolder: deviceName });
             if (!selected) {
                 return;
             }
@@ -124,10 +122,9 @@ export class SvdResolver {
             // Keep existing processor name
         } else if (!processorName && processors.length == 1) {
             processorName = processors[0];
-        } else {
+        } else if (processors.length > 1) {
             // Ask user which processor to use
-            const items = processors.map(label => ({ label }));
-            const selected = await getSelection('Select a processor', items, processorName);
+            const selected = await vscode.window.showQuickPick(processors, { title: 'Select a processor', placeHolder: processorName });
             if (!selected) {
                 return;
             }

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -13,46 +13,6 @@ export const uriExists = async (uri: vscode.Uri): Promise<boolean> => {
     }
 };
 
-interface QuickPickItem extends vscode.QuickPickItem {
-    value?: string;
-}
-
-export const getSelection = async (title: string, items: QuickPickItem[], value?: string): Promise<string | undefined> => {
-    const disposables: vscode.Disposable[] = [];
-    try {
-        return await new Promise<string | undefined>(resolve => {
-            const input = vscode.window.createQuickPick();
-            input.title = title;
-            input.items = items;
-            if (value) {
-                input.value = value;
-            }
-
-            for (const item of items) {
-                if (item.picked === true) {
-                    input.value = item.label;
-                    break;
-                }
-            }
-
-            disposables.push(
-                input.onDidChangeSelection(items => {
-                    const item = items[0] as QuickPickItem;
-                    resolve(item.value || item.label);
-                    input.hide();
-                }),
-                input.onDidHide(() => {
-                    resolve(undefined);
-                    input.dispose();
-                })
-            );
-            input.show();
-        });
-    } finally {
-        disposables.forEach(d => d.dispose());
-    }
-};
-
 let enableLogOutput = false;
 export let logOutputChannel: vscode.OutputChannel | undefined;
 export function setLogOutput(val: boolean) {


### PR DESCRIPTION
Fix situation when there are no processors for a device

Fixes https://github.com/mcu-debug/peripheral-viewer/issues/6

Took the liberty of tidying the `quickPick` functionality, too.