### PR TITLE
Update pack asset service URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
         },
         "mcu-debug.peripheral-viewer.packAssetUrl": {
           "type": "string",
-          "default": "https://pack-asset-service.keil.arm.com",
+          "default": "https://pack-content.cmsis.io",
           "description": "Base URL for CMSIS pack assets"
         },
         "mcu-debug.peripheral-viewer.svdAddrGapThreshold": {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -12,6 +12,6 @@ export const DEFAULT_PROCESSOR = 'processorName';
 export const CONFIG_ADDRGAP = 'svdAddrGapThreshold';
 export const DEFAULT_ADDRGAP = 16;
 export const CONFIG_ASSET_PATH = 'packAssetUrl';
-export const DEFAULT_ASSET_PATH = 'https://pack-asset-service.keil.arm.com';
+export const DEFAULT_ASSET_PATH = 'https://pack-content.cmsis.io';
 export const CONFIG_SAVE_LAYOUT = 'saveLayout';
 export const DEBUG_LEVEL = 'debugLevel';


### PR DESCRIPTION
The pack asset service is moving to a new URL, this PR updates it.