### PR TITLE
Error message improvements

### DIFF
--- a/src/svd-parser.ts
+++ b/src/svd-parser.ts
@@ -349,6 +349,8 @@ export class SVDParser {
                     registers.push(register);
                 }
             } else {
+                if (!r.addressOffset)
+                    throw new Error(`Unable to parse SVD file: register ${r.name[0]} has no addressOffset`);
                 const description = this.cleanupDescription(r.description ? r.description[0] : '');
                 const register = new PeripheralRegisterNode(parent, {
                     ...baseOptions,

--- a/src/svd-parser.ts
+++ b/src/svd-parser.ts
@@ -95,6 +95,9 @@ export class SVDParser {
             defaultOptions.accessType = accessTypeFromString(svdData.device.access[0]);
         }
 
+        if (!svdData.device.peripherals) {
+            throw new Error('Unable to parse SVD file: no peripherals defined');
+        }
         svdData.device.peripherals[0].peripheral.forEach((element) => {
             const name = element.name[0];
             peripheralMap[name] = element;


### PR DESCRIPTION
I encountered some SVD files "in the wild" that peripheral-viewer produces some unhelpful error messages on. Hopefully this PR will save folks in the future some time and headache.

* SEGGER Ozone comes with some SVD files that don't define any peripherals.
* SVD files produced by running [tixml2svd](https://github.com/dhoove/tixml2svd) on XML distributed with TI Code Creator Studio v20.0.2 for TI Hercules Cortex-R MCUs contain some registers that lack addressOffsets.