### PR TITLE
Fix bug where setting svdAddrGapThreshold to 0 in launch.json caused …

### DIFF
--- a/src/views/peripheral.ts
+++ b/src/views/peripheral.ts
@@ -388,7 +388,7 @@ export class PeripheralTreeProvider implements vscode.TreeDataProvider<Periphera
         this.sessionPeripheralsMap.set(session.id, regs);
         let thresh = session.configuration[manifest.CONFIG_ADDRGAP];
 
-        if (!thresh) {
+        if (thresh == undefined) {
             thresh = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<number>(manifest.CONFIG_ADDRGAP) || manifest.DEFAULT_ADDRGAP;
         }
 


### PR DESCRIPTION
…the default gap of 16 to be used instead. Check "thresh == undefined" instead of "!thresh".